### PR TITLE
Fix import path for tests

### DIFF
--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -6,6 +6,9 @@ implemented in subsequent tasks.
 """
 
 from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import pytest
 


### PR DESCRIPTION
## Summary
- ensure `tests` can import project modules by extending `sys.path`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68852a7bc2208330a62eb5e0996a1d62