### PR TITLE
Implement task 4: Ollama communication

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,15 +1,25 @@
 """Core application package for the Codebase Task Runner.
 
-This package will contain modules responsible for scanning files,
+This package exposes utilities for scanning files, counting tokens,
 chunking content, communicating with a local LLM via Ollama, and
-writing results. For now only configuration helpers are defined here.
+writing results.
 """
 
-from . import config_loader, folder_scanner, token_calculator, chunker
+from . import (
+    config_loader,
+    folder_scanner,
+    token_calculator,
+    chunker,
+    ollama_client,
+    task_dispatcher,
+)
 
 __all__ = [
     "config_loader",
     "folder_scanner",
     "token_calculator",
     "chunker",
+    "ollama_client",
+    "task_dispatcher",
 ]
+

--- a/app/ollama_client.py
+++ b/app/ollama_client.py
@@ -1,0 +1,33 @@
+"""Simple API client for communicating with a local Ollama server."""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, List
+
+import requests
+
+__all__ = ["OllamaClient"]
+
+logger = logging.getLogger(__name__)
+
+
+class OllamaClient:
+    """HTTP client for the Ollama chat completion API."""
+
+    def __init__(self, base_url: str) -> None:
+        self.base_url = base_url.rstrip("/")
+
+    def chat(self, model: str, messages: List[Dict[str, str]]) -> str:
+        """Send a chat completion request and return the LLM response text."""
+        url = f"{self.base_url}/v1/chat/completions"
+        payload = {"model": model, "messages": messages}
+        logger.debug("POST %s", url)
+        response = requests.post(url, json=payload, timeout=60)
+        response.raise_for_status()
+        data = response.json()
+        try:
+            return data["choices"][0]["message"]["content"]
+        except (KeyError, IndexError) as exc:  # pragma: no cover - invalid reply
+            logger.error("Unexpected response from Ollama: %s", data)
+            raise RuntimeError("Invalid response from Ollama") from exc

--- a/app/task_dispatcher.py
+++ b/app/task_dispatcher.py
@@ -1,0 +1,46 @@
+"""Coordinate sending file chunks to Ollama and combining the results."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import List
+
+from .chunker import chunk_file, Chunk
+from .ollama_client import OllamaClient
+
+__all__ = ["TaskDispatcher"]
+
+logger = logging.getLogger(__name__)
+
+
+class TaskDispatcher:
+    """Send chunks for a task and combine responses per file."""
+
+    def __init__(self, client: OllamaClient, model: str, token_limit: int) -> None:
+        self.client = client
+        self.model = model
+        self.token_limit = token_limit
+
+    def run_task_on_file(self, path: Path, ask: str) -> str:
+        """Process ``path`` using ``ask`` and return combined LLM output."""
+        chunks = chunk_file(path, max_tokens=self.token_limit)
+        responses: List[str] = []
+        for chunk in chunks:
+            prompt = (
+                f"{ask}\n\nFile: {chunk.file.name}\n"
+                f"Lines {chunk.start_line}-{chunk.end_line}:\n{chunk.content}"
+            )
+            messages = [{"role": "user", "content": prompt}]
+            logger.debug("Sending chunk %s of %s", chunk.index, path)
+            responses.append(self.client.chat(self.model, messages))
+
+        combine_lines = [
+            "Combine the following chunk results into a single answer:",
+        ]
+        for idx, resp in enumerate(responses):
+            combine_lines.append(f"Chunk {idx}: {resp}")
+        final_prompt = "\n".join(combine_lines)
+        final_msg = [{"role": "user", "content": final_prompt}]
+        return self.client.chat(self.model, final_msg)
+

--- a/docs/codebase-runner-full-doc.md
+++ b/docs/codebase-runner-full-doc.md
@@ -291,12 +291,12 @@ Combiner → Output Writer → Logs & Results
   - [x] 3.3 Ensure token limits are respected and logged
   - [x] 3.4 Add test cases for large and edge-case files
 
-- [ ] 4.0 Implement Ollama Communication and Task Flow
-  - [ ] 4.1 Implement API client for Ollama local server
-  - [ ] 4.2 Send each chunk with user-defined prompt
-  - [ ] 4.3 Gather responses per chunk
-  - [ ] 4.4 Send follow-up prompt to combine per-file responses
-  - [ ] 4.5 Allow prompt reuse across files
+- [x] 4.0 Implement Ollama Communication and Task Flow
+  - [x] 4.1 Implement API client for Ollama local server
+  - [x] 4.2 Send each chunk with user-defined prompt
+  - [x] 4.3 Gather responses per chunk
+  - [x] 4.4 Send follow-up prompt to combine per-file responses
+  - [x] 4.5 Allow prompt reuse across files
 
 - [ ] 5.0 Implement Output Aggregation and File Writing
   - [ ] 5.1 Create markdown output writer for documentation

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -1,0 +1,36 @@
+"""Tests for the Ollama API client."""
+
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.ollama_client import OllamaClient
+
+
+def test_ollama_client_chat(monkeypatch):
+    calls = {}
+
+    class FakeResp:
+        status_code = 200
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"choices": [{"message": {"content": "hello"}}]}
+
+    def fake_post(url, json, timeout=60):
+        calls["url"] = url
+        calls["json"] = json
+        return FakeResp()
+
+    import requests
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    client = OllamaClient("http://localhost:11434")
+    result = client.chat("model", [{"role": "user", "content": "hi"}])
+    assert result == "hello"
+    assert calls["json"]["model"] == "model"
+

--- a/tests/test_task_dispatcher.py
+++ b/tests/test_task_dispatcher.py
@@ -1,0 +1,43 @@
+"""Tests for the task dispatcher logic."""
+
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.task_dispatcher import TaskDispatcher
+from app.ollama_client import OllamaClient
+from app.chunker import Chunk
+
+
+def test_dispatcher_combines_chunks(monkeypatch, tmp_path):
+    file_path = tmp_path / "f.py"
+    file_path.write_text("dummy", encoding="utf-8")
+
+    chunks = [
+        Chunk(file=file_path, index=0, start_line=1, end_line=1, content="a"),
+        Chunk(file=file_path, index=1, start_line=2, end_line=2, content="b"),
+    ]
+
+    def fake_chunk_file(path, max_tokens, model=None):
+        return chunks
+
+    monkeypatch.setattr("app.task_dispatcher.chunk_file", fake_chunk_file)
+
+    calls = []
+
+    def fake_chat(self, model, messages):
+        calls.append(messages[0]["content"])
+        if len(calls) < 3:
+            return f"resp{len(calls)}"
+        return "combined"
+
+    monkeypatch.setattr(OllamaClient, "chat", fake_chat)
+
+    client = OllamaClient("http://localhost:11434")
+    dispatcher = TaskDispatcher(client, "model", token_limit=10)
+    result = dispatcher.run_task_on_file(file_path, "Summarize")
+
+    assert result == "combined"
+    assert len(calls) == 3
+


### PR DESCRIPTION
## Summary
- implement Ollama API client
- add TaskDispatcher for sending chunks and combining results
- mark task 4 complete in documentation
- add tests for OllamaClient and TaskDispatcher

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68853cc47f748330911d858e56165a28