### PR TITLE
Implement task 5 output writer

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -12,6 +12,7 @@ from . import (
     chunker,
     ollama_client,
     task_dispatcher,
+    output_writer,
 )
 
 __all__ = [
@@ -21,5 +22,6 @@ __all__ = [
     "chunker",
     "ollama_client",
     "task_dispatcher",
+    "output_writer",
 ]
 

--- a/app/output_writer.py
+++ b/app/output_writer.py
@@ -1,0 +1,51 @@
+"""Utilities for writing task outputs to files."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from datetime import datetime
+
+__all__ = ["OutputWriter"]
+
+logger = logging.getLogger(__name__)
+
+
+class OutputWriter:
+    """Write task results to organized output directories."""
+
+    def __init__(self, base_dir: Path) -> None:
+        self.base_dir = base_dir
+        self.docs_dir = base_dir / "docs"
+        self.tests_dir = base_dir / "tests"
+        self.todos_dir = base_dir / "todos"
+
+    def _write(self, directory: Path, name: str, extension: str, content: str) -> Path:
+        directory.mkdir(parents=True, exist_ok=True)
+        timestamp = datetime.utcnow().isoformat()
+        header = f"Generated on {timestamp}"
+        if extension == ".md":
+            header = f"<!-- {header} -->\n"
+        elif extension == ".cs":
+            header = f"// {header}\n"
+        else:
+            header = f"# {header}\n"
+        path = directory / f"{name}{extension}"
+        path.write_text(f"{header}{content}\n", encoding="utf-8")
+        if path.exists():
+            logger.info("Wrote %s", path)
+        else:
+            logger.error("Failed to write %s", path)
+        return path
+
+    def write_docs(self, name: str, content: str) -> Path:
+        """Write documentation markdown."""
+        return self._write(self.docs_dir, name, ".md", content)
+
+    def write_tests(self, name: str, content: str) -> Path:
+        """Write C# unit tests."""
+        return self._write(self.tests_dir, name, ".cs", content)
+
+    def write_todos(self, name: str, content: str) -> Path:
+        """Write TODO report."""
+        return self._write(self.todos_dir, name, ".txt", content)

--- a/docs/codebase-runner-full-doc.md
+++ b/docs/codebase-runner-full-doc.md
@@ -298,12 +298,12 @@ Combiner → Output Writer → Logs & Results
   - [x] 4.4 Send follow-up prompt to combine per-file responses
   - [x] 4.5 Allow prompt reuse across files
 
-- [ ] 5.0 Implement Output Aggregation and File Writing
-  - [ ] 5.1 Create markdown output writer for documentation
-  - [ ] 5.2 Create .cs writer for unit test generation
-  - [ ] 5.3 Organize outputs by task (docs/, tests/, todos/)
-  - [ ] 5.4 Add timestamped logs or headers to outputs
-  - [ ] 5.5 Validate and log file save success
+- [x] 5.0 Implement Output Aggregation and File Writing
+  - [x] 5.1 Create markdown output writer for documentation
+  - [x] 5.2 Create .cs writer for unit test generation
+  - [x] 5.3 Organize outputs by task (docs/, tests/, todos/)
+  - [x] 5.4 Add timestamped logs or headers to outputs
+  - [x] 5.5 Validate and log file save success
 
 - [ ] 6.0 Add CLI Interface and Logging
   - [ ] 6.1 Build CLI using argparse or click

--- a/tests/test_output_writer.py
+++ b/tests/test_output_writer.py
@@ -1,0 +1,34 @@
+"""Tests for the output writer utilities."""
+
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.output_writer import OutputWriter
+
+
+def test_write_docs(tmp_path):
+    writer = OutputWriter(tmp_path)
+    path = writer.write_docs("sample", "hello")
+    assert path.exists()
+    text = path.read_text(encoding="utf-8")
+    assert "hello" in text
+    assert path.suffix == ".md"
+    assert path.parent.name == "docs"
+
+
+def test_write_tests(tmp_path):
+    writer = OutputWriter(tmp_path)
+    path = writer.write_tests("sample", "// test")
+    assert path.exists()
+    assert path.suffix == ".cs"
+    assert path.parent.name == "tests"
+
+
+def test_write_todos(tmp_path):
+    writer = OutputWriter(tmp_path)
+    path = writer.write_todos("sample", "todo")
+    assert path.exists()
+    assert path.suffix == ".txt"
+    assert path.parent.name == "todos"


### PR DESCRIPTION
## Summary
- implement `OutputWriter` module
- export output writer in `app.__init__`
- update docs to mark task 5 complete
- add tests for output writer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885426d279c83309229e90ae026e5e2